### PR TITLE
Allow the onSelect handler to reject selection

### DIFF
--- a/demo/Example.js
+++ b/demo/Example.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Calendar from '../lib/Calendar.js';
+import moment from 'moment';
 
 
 var Example = React.createClass({
 
     onSelect: function (date) {
-        console.info('onSelect', date);
+        if (moment().isSame(date, 'month')) {
+            console.info('onSelect', date);
+        } else {
+            return false;
+        }
     },
 
     render: function() {

--- a/demo/bundle.js
+++ b/demo/bundle.js
@@ -15,11 +15,19 @@ var _libCalendarJs = require('../lib/Calendar.js');
 
 var _libCalendarJs2 = _interopRequireDefault(_libCalendarJs);
 
+var _moment = require('moment');
+
+var _moment2 = _interopRequireDefault(_moment);
+
 var Example = _react2['default'].createClass({
     displayName: 'Example',
 
     onSelect: function onSelect(date) {
-        console.info('onSelect', date);
+        if ((0, _moment2['default'])().isSame(date, 'month')) {
+            console.info('onSelect', date);
+        } else {
+            return false;
+        }
     },
 
     render: function render() {
@@ -30,7 +38,7 @@ var Example = _react2['default'].createClass({
 
 _reactDom2['default'].render(_react2['default'].createElement(Example, null), document.getElementById("container"));
 
-},{"../lib/Calendar.js":2,"react":163,"react-dom":8}],2:[function(require,module,exports){
+},{"../lib/Calendar.js":2,"moment":7,"react":163,"react-dom":8}],2:[function(require,module,exports){
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -91,10 +99,11 @@ exports['default'] = _react2['default'].createClass({
     },
 
     handleClick: function handleClick(date) {
-        this.props.onSelect(date);
-        this.setState({
-            date: (0, _moment2['default'])(date)
-        });
+        if (this.props.onSelect(date) !== false) {
+            this.setState({
+                date: (0, _moment2['default'])(date)
+            });
+        }
     },
 
     previous: function previous() {

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -34,10 +34,11 @@ export default React.createClass({
     },
 
     handleClick(date) {
-        this.props.onSelect(date);
-        this.setState({
-            date: moment(date)
-        });
+        if (this.props.onSelect(date) !== false) {
+            this.setState({
+                date: moment(date)
+            });
+        }
     },
 
     previous() {


### PR DESCRIPTION
If you return false from onSelect, it will not select
the day.  To keep it backwards compatible, returning
undefined _will_ select the day.

Also updated the demo to reject selection on days
in different months.
